### PR TITLE
Add Haskell to CSCI 4450

### DIFF
--- a/dockerfiles/csci4450/ubuntu22.04/Dockerfile
+++ b/dockerfiles/csci4450/ubuntu22.04/Dockerfile
@@ -40,4 +40,8 @@ RUN apt-get update \
   && chmod -R 755 ${SUBMITTY_INSTALL_DIR}/java_tools \
   && apt-get purge -y --auto-remove curl
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ghc=8.8.4-3 cabal-install=3.0.0.0-3build1.1 \
+  && rm -rf /var/lib/apt/lists/*
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This adds the Haskell compiler to the CSCI 4450 image.