### PR TITLE
Update action to v24.07.00

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -7,11 +7,12 @@ on:
 
 jobs:
   call-docker-build-push:
-    uses: submitty/action-docker-build/.github/workflows/docker-build-push.yml@v24.06.00
+    uses: submitty/action-docker-build/.github/workflows/docker-build-push.yml@v24.07.00
     with:
       push: true
-      docker_username: ${{ vars.docker_username }}
+      docker_org_name: ${{ vars.docker_org_name }}
       base_commit: ${{ github.event.before }}
       head_commit: ${{ github.event.after }}
     secrets:
+      docker_username: ${{ secrets.docker_username }}
       docker_password: ${{ secrets.docker_password }}


### PR DESCRIPTION
Updates github action from v24.06.00 to v24.07.00 to have a separated org name and username.