### PR TITLE
Change Docker org name var to string

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,7 +10,7 @@ jobs:
     uses: submitty/action-docker-build/.github/workflows/docker-build-push.yml@v24.07.00
     with:
       push: true
-      docker_org_name: ${{ vars.docker_org_name }}
+      docker_org_name: submittyrpi
       base_commit: ${{ github.event.before }}
       head_commit: ${{ github.event.after }}
     secrets:


### PR DESCRIPTION
This switches the Docker org name repo variable to a string. This was done for consistency of https://github.com/Submitty/DockerImages/pull/44.