### PR TITLE
Install CPU-only Torch

### DIFF
--- a/dockerfiles/csci4150/s25/Dockerfile
+++ b/dockerfiles/csci4150/s25/Dockerfile
@@ -4,4 +4,6 @@ RUN apt-get update
 
 RUN apt-get install python3.10 pip -y
 
-RUN pip install torch==2.6.0 numpy==2.2.4 matplotlib==3.10.1
+RUN pip install numpy==2.2.4 matplotlib==3.10.1
+
+RUN pip install torch==2.6.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
We couldn't find much about the error Submitty was giving us online, but ChatGPT said it had to do with trying to load CUDA which makes sense since we don't have access to it, so I've changed the environment to install the CPU-only version of torch. Hopefully, this fixes the error.