### PR TITLE
[Bugfix:Autograding] CSCI4270 Reduce Thread Limit

### DIFF
--- a/dockerfiles/csci4270/metadata.json
+++ b/dockerfiles/csci4270/metadata.json
@@ -1,4 +1,4 @@
 {
     "pushLatest": true,
-    "latestTag": "spring26_v3"
+    "latestTag": "spring26_v4"
 }

--- a/dockerfiles/csci4270/spring26_v4/Dockerfile
+++ b/dockerfiles/csci4270/spring26_v4/Dockerfile
@@ -1,0 +1,170 @@
+FROM ubuntu:22.04
+
+ARG TARGETPLATFORM
+
+# runtime dependencies
+RUN apt-get update \
+    	&& apt-get -y --no-install-recommends install \
+      	grep \
+      	libseccomp-dev \
+      	libseccomp2 \
+      	procps \
+		ca-certificates \
+		netbase \
+	  	libgl1 \
+	  	libglib2.0-0 \
+	  	libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/*
+#
+# Source: https://github.com/docker-library/python/blob/master/3.6/stretch/slim/Dockerfile
+#
+
+# ensure local python is preferred over distribution python
+ENV PATH=/usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG=C.UTF-8
+ENV GPG_KEY=64E628F8D684696D
+ENV PYTHON_VERSION=3.11.14
+
+RUN set -ex \
+	\
+	&& savedAptMark="$(apt-mark showmanual)" \
+	&& apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		dpkg-dev \
+		gcc \
+		libbz2-dev \
+		libc6-dev \
+		libexpat1-dev \
+		libffi-dev \
+		libgdbm-dev \
+		liblzma-dev \
+		libncursesw5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		make \
+		tk-dev \
+		wget \
+		xz-utils \
+		zlib1g-dev \
+# as of Stretch, "gpg" is no longer included by default
+		$(command -v gpg > /dev/null || echo 'gnupg dirmngr') \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+	&& make install \
+	&& ldconfig \
+	\
+	&& apt-mark auto '.*' > /dev/null \
+	&& apt-mark manual $savedAptMark \
+	&& find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+	&& rm -rf /usr/src/python \
+	\
+	&& python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3 python \
+	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION=23.3.2
+
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends wget; \
+	\
+	wget -O get-pip.py 'https://bootstrap.pypa.io/pip/get-pip.py'; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	python get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py; \
+	pip3 install --no-cache-dir \
+        numpy \
+        pandas \
+        matplotlib \
+        scipy \
+		scikit-learn \
+        opencv-python-headless \
+        jupyter; \
+	pip3 install --no-cache-dir \
+        torch \
+        torchvision \
+        --index-url https://download.pytorch.org/whl/cpu; \
+    \
+	pip3 uninstall --yes pip setuptools
+
+# Necessary as Submitty does path expansion of commands in compiling a homework,
+# and so resolves "python" -> "/usr/bin/python"
+RUN cd /usr/bin \
+	&& ln -s /usr/local/bin/python3 python3 \
+	&& ln -s /usr/local/bin/python3 python \
+	&& ln -s /usr/local/bin/pip3 pip3 \
+	&& ln -s /usr/local/bin/pip3 pip
+
+# Necessary to limit thread spawning to avoid jupyter kernel crashes
+ENV OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    BLIS_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1 \
+    TORCH_NUM_THREADS=1
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Autograding for CV assignments can fail due to out-of-memory errors when running OpenCV and NumPy operations on moderately large images inside the Docker container. A short term fix to lower memory count is to reduce the thread limit. In the long-term we would need to up the docker container memory limit to accommodate CV-related assignments.